### PR TITLE
Created frontend for creating and deleting workout templates.

### DIFF
--- a/frontend/src/pages/Templates.js
+++ b/frontend/src/pages/Templates.js
@@ -6,8 +6,8 @@ import { useTemplatessContext } from '../hooks/useTemplateContext';
 import { useAuthContext } from '../hooks/useAuthContext';
 
 const Template = () => {
-  const { templates, dispatch } = useTemplatessContext(); 
-  const { user } = useAuthContext(); 
+  const { templates, dispatch } = useTemplatessContext();
+  const { user } = useAuthContext();
 
   useEffect(() => {
     const fetchTemplates = async () => {
@@ -44,7 +44,6 @@ const Template = () => {
     }
   };
 
-  // Handle deleting a template
   const handleDeleteTemplate = async (templateId) => {
     const response = await fetch(`/api/templates/${templateId}`, {
       method: 'DELETE',
@@ -58,7 +57,6 @@ const Template = () => {
     }
   };
 
-  // Handle editing an existing template
   const handleEditTemplate = async (updatedTemplate) => {
     const response = await fetch(`/api/templates/${updatedTemplate._id}`, {
       method: 'PATCH',
@@ -76,7 +74,7 @@ const Template = () => {
   };
 
   return (
-<Container maxWidth="lg" sx={{ marginTop: 4 }}>
+    <Container maxWidth="lg" sx={{ marginTop: 4 }}>
       <Grid container spacing={4}>
         {/* Header */}
         <Grid item xs={12}>
@@ -87,7 +85,7 @@ const Template = () => {
 
         {/* Form Section */}
         <Grid item xs={12} md={6}>
-          <Paper elevation={3} sx={{ padding: 3 }}>
+          <Paper elevation={3} sx={{ padding: 3, borderRadius: '12px', backgroundColor: '#f5f5f5' }}>
             <Typography variant="h6" gutterBottom>
               Create New Template
             </Typography>
@@ -97,7 +95,7 @@ const Template = () => {
 
         {/* List Section */}
         <Grid item xs={12} md={6}>
-          <Paper elevation={3} sx={{ padding: 3 }}>
+          <Paper elevation={3} sx={{ padding: 3, borderRadius: '12px', backgroundColor: '#f5f5f5' }}>
             <Typography variant="h6" gutterBottom>
               Available Templates
             </Typography>
@@ -112,6 +110,5 @@ const Template = () => {
     </Container>
   );
 };
-
 
 export default Template;


### PR DESCRIPTION
Closes Issue #8

This PR addresses the issue related to adding frontend functionality to manage workout templates. The following features have been implemented:

**Key Changes:**

**Create New Template:**
Integrated a form for creating new workout templates.
Connected the form submission to the backend API to save templates.
On successful submission, the new template is added to the list of templates displayed on the page.

**View & Delete Available Templates:**

Added functionality to fetch and display existing workout templates in a list format.
Added the ability to delete workout templates by clicking the delete button.
This action removes the template from both the frontend list and the backend database.

Code Summary:
The main logic has been added in the Template component.
Fetching, saving, editing, and deleting templates is handled via API calls with authentication using Bearer tokens.
User authentication context (useAuthContext) is integrated to ensure only authenticated users can manage templates.

**How to Test:**
Log in with an authenticated user account.
Navigate to the "Templates" page.

![WhatsApp Image 2024-10-16 at 19 57 17_38068c5a](https://github.com/user-attachments/assets/5847e814-243a-41e5-92da-074f4552e2a5)


**Test the following:**
Create a new template: Fill out the form and submit.
View templates : Click on the template and check out which excercise it consists of.
Delete a template: Click the delete button and verify the template is removed.