### PR TITLE
Add new workout goals page for adding and displaying goals

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15,6 +15,7 @@
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
+        "axios": "^1.7.7",
         "chart.js": "^4.4.5",
         "date-fns": "^4.1.0",
         "dayjs": "^1.11.13",
@@ -5841,6 +5842,29 @@
       "integrity": "sha512-M0JtH+hlOL5pLQwHOLNYZaXuhqmvS8oExsqB1SBYgA4Dk7u/xx+YdGHXaK5pyUfed5mYXdlYiphWq3G8cRi5JQ==",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
+      "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.1.tgz",
+      "integrity": "sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/axobject-query": {
@@ -15122,6 +15146,11 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/psl": {
       "version": "1.9.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
+    "axios": "^1.7.7",
     "chart.js": "^4.4.5",
     "date-fns": "^4.1.0",
     "dayjs": "^1.11.13",

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -6,6 +6,7 @@ import Login from './pages/Login';
 import Signup from './pages/Signup';
 import Templates from './pages/Templates';
 import Dashboard from './pages/Dashboard';
+import GoalsComponent from './pages/Goal';
 
 function App() {
   const {user}=useAuthContext()
@@ -36,7 +37,10 @@ function App() {
               path='/signup'
               element={!user?<Signup/>:<Navigate to ='/'/>}
             />
-            
+            <Route
+            path='/goals'
+            element={<GoalsComponent/>}
+            />
 
           </Routes>
         </div>

--- a/frontend/src/components/Navbar.js
+++ b/frontend/src/components/Navbar.js
@@ -24,8 +24,8 @@ const Navbar = () => {
                 <nav>
                     {user && (
                     <div>
-                        <span>{user.email}</span>
-                        <button onClick={handleClick}>Log out</button>
+                        {/* <span>{user.email}</span> */}
+                       
                         <Link
           to="/dashboard" // Replace with the actual route for your templates page
           className="bg-blue-500 text-white  rounded-md shadow-md hover:bg-blue-600 transition pr-2"
@@ -38,6 +38,13 @@ const Navbar = () => {
         >
            Templates
         </Link>
+        <Link
+          to="/goals" // Replace with the actual route for your templates page
+          className="bg-blue-500 text-white  rounded-md shadow-md hover:bg-blue-600 transition"
+        >
+           Goals
+        </Link>
+        
                     </div>
                     )}
                     {!user && (<div>
@@ -46,6 +53,7 @@ const Navbar = () => {
                     </div>
                     )}
                  <DarkModeToggle />
+                 <button onClick={handleClick}>Log out</button>
                 </nav>
             </div>
         </header>

--- a/frontend/src/pages/Goal.js
+++ b/frontend/src/pages/Goal.js
@@ -1,0 +1,166 @@
+import React, { useState, useEffect } from 'react';
+import {
+  Card, CardContent, Typography, Button, TextField, Grid, LinearProgress, IconButton, Box, Paper
+} from '@mui/material';
+import DeleteIcon from '@mui/icons-material/Delete';
+import AddIcon from '@mui/icons-material/Add';
+import SaveIcon from '@mui/icons-material/Save';
+import axios from 'axios';
+import { useAuthContext } from '../hooks/useAuthContext';
+
+const GoalsComponent = () => {
+  const [goals, setGoals] = useState([{ exercise: '', targetLoad: '', targetReps: '' }]);
+  const { user } = useAuthContext();
+ 
+  const fetchGoals = async () => {
+    try {
+      const res = await axios.get('/api/user/goals', {
+        headers: {
+          Authorization: `Bearer ${user.token}`,
+        },
+      });
+      setGoals(res.data);
+      console.log(res.data);
+    } catch (err) {
+      console.error('Error fetching goals', err);
+    }
+  };
+
+  useEffect(() => {
+    fetchGoals();
+  }, [user]);
+
+  const handleInputChange = (index, field, value) => {
+    const updatedGoals = [...goals];
+    updatedGoals[index][field] = value;
+    setGoals(updatedGoals);
+  };
+
+  const handleAddGoal = () => {
+    setGoals([...goals, { exercise: '', targetLoad: '', targetReps: '' }]);
+  };
+
+  const handleSubmit = async () => {
+    try {
+      await axios.post('/api/user/goals', { goals }, {
+        headers: {
+          Authorization: `Bearer ${user.token}`,
+        },
+      });
+      fetchGoals();
+    } catch (error) {
+      console.error('Error submitting goals', error);
+    }
+  };
+
+  const handleDelete = async (exercise) => {
+    try {
+      const res = await axios.delete(`/api/user/goals/${exercise}`, {
+        headers: {
+          Authorization: `Bearer ${user.token}`,
+        },
+      });
+      setGoals(res.data.goals);
+    } catch (err) {
+      console.error('Error deleting goal', err);
+    }
+  };
+
+  return (
+    <Card sx={{ margin: 4, padding: 2, boxShadow: 3, borderRadius: 2 }}>
+      <CardContent>
+        <Typography variant="h4" gutterBottom sx={{ fontWeight: 'bold', color: '#1565C0' }}>
+          Workout Goals
+        </Typography>
+
+        <Grid container spacing={4} sx={{ marginTop: 2 }}>
+          {goals.map((goal, index) => (
+            <Grid item xs={12} md={6} key={index}>
+              <Paper elevation={4} sx={{ padding: 2, borderRadius: 3 }}>
+                <CardContent>
+                  <Typography variant="h6" gutterBottom sx={{ color: '#1E88E5' }}>
+                    {goal.exercise || 'New Goal'}
+                  </Typography>
+                  <Typography variant="body1" sx={{ marginBottom: 1 }}>
+                    <strong>Target Load:</strong> {goal.targetLoad} kg
+                  </Typography>
+                  <Typography variant="body1" sx={{ marginBottom: 2 }}>
+                    <strong>Target Reps:</strong> {goal.targetReps}
+                  </Typography>
+                  <LinearProgress
+                    variant="determinate"
+                    value={Math.random() * 100}
+                    sx={{ height: 10, borderRadius: 5, marginBottom: 2 }}
+                  />
+                  <IconButton color="error" onClick={() => handleDelete(goal.exercise)}>
+                    <DeleteIcon />
+                  </IconButton>
+                </CardContent>
+              </Paper>
+            </Grid>
+          ))}
+        </Grid>
+
+        {/* Form for adding goals */}
+        {goals.map((goal, index) => (
+          <Box key={index} mt={4}>
+            <Typography variant="h6" sx={{ color: '#42A5F5' }}>Goal {index + 1}</Typography>
+            <TextField
+              label="Exercise"
+              value={goal.exercise}
+              onChange={(e) => handleInputChange(index, 'exercise', e.target.value)}
+              fullWidth
+              margin="normal"
+              variant="outlined"
+              sx={{ marginBottom: 2 }}
+            />
+            <Grid container spacing={2}>
+              <Grid item xs={6}>
+                <TextField
+                  label="Target Load (kg)"
+                  value={goal.targetLoad}
+                  onChange={(e) => handleInputChange(index, 'targetLoad', e.target.value)}
+                  fullWidth
+                  margin="normal"
+                  variant="outlined"
+                />
+              </Grid>
+              <Grid item xs={6}>
+                <TextField
+                  label="Target Reps"
+                  value={goal.targetReps}
+                  onChange={(e) => handleInputChange(index, 'targetReps', e.target.value)}
+                  fullWidth
+                  margin="normal"
+                  variant="outlined"
+                />
+              </Grid>
+            </Grid>
+          </Box>
+        ))}
+
+        <Box display="flex" justifyContent="flex-end" alignItems="center" mt={4}>
+          <Button
+            onClick={handleAddGoal}
+            variant="outlined"
+            color="primary"
+            startIcon={<AddIcon />}
+            sx={{ marginRight: 2 }}
+          >
+            Add Goal
+          </Button>
+          <Button
+            onClick={handleSubmit}
+            variant="contained"
+            color="primary"
+            startIcon={<SaveIcon />}
+          >
+            Save Goals
+          </Button>
+        </Box>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default GoalsComponent;


### PR DESCRIPTION
**Description:** This PR introduces a new page that allows users to add, update, and delete workout goals. The page is integrated with the backend API and displays the user's existing goals in a visually appealing way.

**Features:**

Workout Goals Display: Users can view their current workout goals, including exercise names, target load (kg), and target repetitions.
Add New Goals: Users can add new workout goals using input fields for Exercise, Target Load (kg), and Target Reps.
Update Existing Goals: Users can modify the existing goals in real time by editing input fields.
Delete Goals: Users can remove any workout goal by clicking on the delete button next to the goal.
API Integration: The page is connected to the /api/user/goals endpoint for fetching, creating, updating, and deleting goals.

**How to Test:**
Navigate to the workout goals page.
Verify that existing workout goals are displayed correctly with appropriate data.
Add a new goal using the form, and check if the goal appears in the list after submission.
Modify a goal by changing its target load or reps, then save the changes.
Delete a goal and ensure it is removed from the list.
Check the responsiveness of the page on different screen sizes.

**Screenshots:** 
![image](https://github.com/user-attachments/assets/aef82617-7551-467a-ac24-0579d0425bf5)
![image](https://github.com/user-attachments/assets/5aab5cc9-e58f-4429-9674-ef7b75cccd2c)

